### PR TITLE
修复 npm install 版本冲突问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "rollup": "^3.26.3",
     "stylelint": "^15.10.1",
     "stylelint-config-html": "^1.1.0",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-recommended": "^13.0.0",
     "stylelint-config-standard": "^34.0.0",
     "stylelint-order": "^6.0.3",


### PR DESCRIPTION
执行 npm install 报错，原因为版本冲突：

![WindowsTerminal_h05Nl1F8xV](https://github.com/yiding-he/vue-element-plus-admin/assets/900606/67542e47-db9b-4fb1-aa86-298324b3f51d)

查看[ stylelint-config-prettier 库的文档](https://www.npmjs.com/package/stylelint-config-prettier)，发现 stylelint 15 以上版本已经不需要这个依赖了，所以可以去掉：

![firefox_uxo0w8V5gL](https://github.com/yiding-he/vue-element-plus-admin/assets/900606/b81e4750-b29d-44db-9700-39a7cea079f1)
